### PR TITLE
Make bash wrappers executable from any directory

### DIFF
--- a/brain4it-server/brain4it-server-raspberrypi/src/main/bin/shutdown.sh
+++ b/brain4it-server/brain4it-server-raspberrypi/src/main/bin/shutdown.sh
@@ -1,4 +1,4 @@
 # Brain4it server shutdown
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 rm -f ../conf/shutdown

--- a/brain4it-server/brain4it-server-raspberrypi/src/main/bin/shutdown.sh
+++ b/brain4it-server/brain4it-server-raspberrypi/src/main/bin/shutdown.sh
@@ -1,5 +1,4 @@
 # Brain4it server shutdown
 
+cd $(dirname $0)
 rm -f ../conf/shutdown
-
-

--- a/brain4it-server/brain4it-server-raspberrypi/src/main/bin/startup.sh
+++ b/brain4it-server/brain4it-server-raspberrypi/src/main/bin/startup.sh
@@ -1,4 +1,4 @@
 # Brain4it server startup
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 java -cp "../lib/*" -Djava.util.logging.manager=org.brain4it.server.standalone.ServerLogManager -Djava.util.logging.config.file="../conf/logging.properties" org.brain4it.server.raspberrypi.RaspberryPiRunner ../conf/server.properties

--- a/brain4it-server/brain4it-server-raspberrypi/src/main/bin/startup.sh
+++ b/brain4it-server/brain4it-server-raspberrypi/src/main/bin/startup.sh
@@ -1,3 +1,4 @@
 # Brain4it server startup
 
+cd $(dirname $0)
 java -cp "../lib/*" -Djava.util.logging.manager=org.brain4it.server.standalone.ServerLogManager -Djava.util.logging.config.file="../conf/logging.properties" org.brain4it.server.raspberrypi.RaspberryPiRunner ../conf/server.properties

--- a/brain4it-server/brain4it-server-standalone/src/main/bin/shutdown.sh
+++ b/brain4it-server/brain4it-server-standalone/src/main/bin/shutdown.sh
@@ -1,4 +1,4 @@
 # Brain4it server shutdown
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 rm -f ../conf/shutdown

--- a/brain4it-server/brain4it-server-standalone/src/main/bin/shutdown.sh
+++ b/brain4it-server/brain4it-server-standalone/src/main/bin/shutdown.sh
@@ -1,5 +1,4 @@
 # Brain4it server shutdown
 
+cd $(dirname $0)
 rm -f ../conf/shutdown
-
-

--- a/brain4it-server/brain4it-server-standalone/src/main/bin/startup.sh
+++ b/brain4it-server/brain4it-server-standalone/src/main/bin/startup.sh
@@ -1,4 +1,4 @@
 # Brain4it server startup
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 java -cp "../lib/*" -Djava.util.logging.manager=org.brain4it.server.standalone.ServerLogManager -Djava.util.logging.config.file="../conf/logging.properties" org.brain4it.server.standalone.Runner ../conf/server.properties

--- a/brain4it-server/brain4it-server-standalone/src/main/bin/startup.sh
+++ b/brain4it-server/brain4it-server-standalone/src/main/bin/startup.sh
@@ -1,3 +1,4 @@
 # Brain4it server startup
 
+cd $(dirname $0)
 java -cp "../lib/*" -Djava.util.logging.manager=org.brain4it.server.standalone.ServerLogManager -Djava.util.logging.config.file="../conf/logging.properties" org.brain4it.server.standalone.Runner ../conf/server.properties

--- a/brain4it-server/brain4it-server-swing/src/main/bin/shutdown.sh
+++ b/brain4it-server/brain4it-server-swing/src/main/bin/shutdown.sh
@@ -1,4 +1,4 @@
 # Brain4it server shutdown
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 rm -f ../conf/shutdown

--- a/brain4it-server/brain4it-server-swing/src/main/bin/shutdown.sh
+++ b/brain4it-server/brain4it-server-swing/src/main/bin/shutdown.sh
@@ -1,3 +1,4 @@
 # Brain4it server shutdown
 
+cd $(dirname $0)
 rm -f ../conf/shutdown

--- a/brain4it-server/brain4it-server-swing/src/main/bin/startup.sh
+++ b/brain4it-server/brain4it-server-swing/src/main/bin/startup.sh
@@ -1,3 +1,4 @@
 # Brain4it server startup
 
+cd $(dirname $0)
 java -cp "../lib/*" -Djava.util.logging.manager=org.brain4it.server.standalone.ServerLogManager -Djava.util.logging.config.file="../conf/logging.properties" org.brain4it.server.swing.SwingRunner ../conf/server.properties

--- a/brain4it-server/brain4it-server-swing/src/main/bin/startup.sh
+++ b/brain4it-server/brain4it-server-swing/src/main/bin/startup.sh
@@ -1,4 +1,4 @@
 # Brain4it server startup
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 java -cp "../lib/*" -Djava.util.logging.manager=org.brain4it.server.standalone.ServerLogManager -Djava.util.logging.config.file="../conf/logging.properties" org.brain4it.server.swing.SwingRunner ../conf/server.properties


### PR DESCRIPTION
Change the working directory of the start/stop scripts so that they can resolve the relative paths correctly and therefore always find the classpath, config, etc.

We extract the information from the `$0` variable, that contains the full path of the program name. With `dirname`, we extract the path part and leave aside the basename (like `startup.sh`).

This change enables the wrappers to be executed by systemd, or by a desktop launcher, for instance.